### PR TITLE
Fix spec exit code

### DIFF
--- a/gulp/tasks/spec.js
+++ b/gulp/tasks/spec.js
@@ -6,8 +6,4 @@ var gulp = require('gulp'),
 gulp.task('spec', function(){
   return gulp.src(config.src, {read: false})
         .pipe(mocha({reporter: 'spec'}))
-        .on('error', function(err){
-          gutil.log(err);
-          this.emit('end');
-        });
 });


### PR DESCRIPTION
Gulp spec task was swallowing the spec runner errors, so the run exited with `0` instead of `1`. CI would always think that all went smooth. This is particularly problematic with something like greenkeeper PRs because we mostly rely on CI result to merge or not.

Fixes #4